### PR TITLE
Add validation for empty payment create response (e.g. when request timed out with 504 HTTP response code)

### DIFF
--- a/src/Entity/Response/PaymentCreateResponse.php
+++ b/src/Entity/Response/PaymentCreateResponse.php
@@ -4,8 +4,8 @@ namespace Comgate\SDK\Entity\Response;
 
 use Comgate\SDK\Exception\Api\MissingParamException;
 use Comgate\SDK\Exception\ApiException;
-use Comgate\SDK\Http\Response;
 use Comgate\SDK\Http\Query;
+use Comgate\SDK\Http\Response;
 
 class PaymentCreateResponse
 {
@@ -26,6 +26,10 @@ class PaymentCreateResponse
 	public function __construct(Response $paymentsCreateResponse)
 	{
 		$parsedResponse = Query::parse($paymentsCreateResponse->getContent());
+
+		if ([] === $parsedResponse) {
+			throw new ApiException($paymentsCreateResponse->getContent());
+		}
 
 		$code = (int) $parsedResponse['code'];
 		$message = $parsedResponse['message'];


### PR DESCRIPTION
Introduce a check to handle cases where the payment response content is empty. 

This may occur if the request times out with an HTTP 504 response. In such cases, the response contains only the string `error code: 504`. This fix handle this and ensures proper error handling by throwing an exception, improving robustness and preventing unexpected behavior. in following code.

