### PR TITLE
 Implicitly marking function parameters as nullable is deprecated. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,3 +275,4 @@ Thank you for using our Comgate payment.
 ## License
 
 Copyright (c) 2024 Comgate a.s. [MIT Licensed](LICENSE).
+

--- a/README.md
+++ b/README.md
@@ -275,4 +275,3 @@ Thank you for using our Comgate payment.
 ## License
 
 Copyright (c) 2024 Comgate a.s. [MIT Licensed](LICENSE).
-

--- a/src/Client.php
+++ b/src/Client.php
@@ -68,7 +68,7 @@ class Client
 		return new PaymentStatusResponse($statusResponse);
 	}
 
-	public function getMethods(MethodsRequest $methodsRequest = null): MethodsResponse
+	public function getMethods(?MethodsRequest $methodsRequest = null): MethodsResponse
 	{
 		if (($methodsRequest instanceof MethodsRequest) === false) {
 			$methodsRequest = new MethodsRequest();

--- a/src/Http/Transport.php
+++ b/src/Http/Transport.php
@@ -17,7 +17,7 @@ class Transport implements ITransport
 	/** @var LoggerInterface | null */
 	private $logger;
 
-	public function __construct(Config $config, LoggerInterface $logger = null)
+	public function __construct(Config $config, ?LoggerInterface $logger = null)
 	{
 		$this->config = $config;
 		$this->logger = $logger;


### PR DESCRIPTION
The explicit nullable type must be used instead. Deprecated in PHP >= 8.4

https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated