### PR TITLE
Handle null message in PaymentStatusResponse constructor

### DIFF
--- a/src/Entity/Response/PaymentStatusResponse.php
+++ b/src/Entity/Response/PaymentStatusResponse.php
@@ -125,7 +125,7 @@ class PaymentStatusResponse
 		$parsedResponse = json_decode($paymentStatusResponse->getContent(), true);
 
 		$code = (int) $parsedResponse['code'];
-		$message = $parsedResponse['message'];
+		$message = (string) ($parsedResponse['message'] ?? '');
 
                 switch ($code) {
                     case 0:

--- a/tests/Unit/Entity/Response/PaymentStatusResponseCest.php
+++ b/tests/Unit/Entity/Response/PaymentStatusResponseCest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Unit\Entity;
+
+use Codeception\Stub;
+use Comgate\SDK\Entity\Response\PaymentStatusResponse;
+use Comgate\SDK\Http\Response;
+use Tests\Support\UnitTester;
+
+class PaymentStatusResponseCest
+{
+	public function statusWithoutMessageTest(UnitTester $I)
+	{
+		$responseMock = Stub::make(Response::class, [
+			'getContent' => '{"code":0,"transId":"AB12-CD34-EF56","status":"PAID","price":"10000","curr":"CZK"}',
+		]);
+
+		$response = new PaymentStatusResponse($responseMock);
+
+		$I->assertEquals(0, $response->getCode());
+		$I->assertEquals('', $response->getMessage());
+		$I->assertEquals('AB12-CD34-EF56', $response->getTransId());
+		$I->assertEquals('PAID', $response->getStatus());
+	}
+}


### PR DESCRIPTION
Fixes #112.

On PHP 8.4+ with strict types, `setMessage(string $message)` throws a `TypeError` when a payment status response has no `message` field, which happens on some successful status checks. `PaymentStatusResponse::__construct` read `$parsedResponse['message']` directly, so a missing or null value was passed straight through.

Coalesce to an empty string before use, matching how the other fields in the constructor already handle absent keys. Added a unit test covering a status response without a message.